### PR TITLE
Updated callback implementation

### DIFF
--- a/config/src/main/java/io/scalecube/config/ConfigRegistryImpl.java
+++ b/config/src/main/java/io/scalecube/config/ConfigRegistryImpl.java
@@ -24,7 +24,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -66,7 +65,7 @@ final class ConfigRegistryImpl implements ConfigRegistry {
 
   private volatile Map<String, ConfigProperty> propertyMap;
 
-  private final ConcurrentMap<String, Collection<BiConsumer>> propertyCallbacks = new ConcurrentHashMap<>();
+  private final ConcurrentMap<String, PropertyCallback> propertyCallbacks = new ConcurrentHashMap<>();
 
   private final LinkedHashMap<ConfigEvent, Object> recentConfigEvents = new LinkedHashMap<ConfigEvent, Object>() {
     @Override
@@ -353,17 +352,9 @@ final class ConfigRegistryImpl implements ConfigRegistry {
   }
 
   private void invokeCallbacks(ConfigEvent event) {
-    Collection<BiConsumer> collection = propertyCallbacks.get(event.getName());
-    if (collection != null && !collection.isEmpty()) {
-      for (BiConsumer callback : collection) {
-        try {
-          // noinspection unchecked
-          callback.accept(event.getOldValue(), event.getNewValue());
-        } catch (Exception e) {
-          LOGGER.error("Exception occurred on property-change callback: {}, event: {}, cause: {}",
-              callback, event, e, e);
-        }
-      }
+    PropertyCallback propertyCallback = propertyCallbacks.get(event.getName());
+    if (propertyCallback != null) {
+      propertyCallback.accept(event.getOldValue(), event.getNewValue());
     }
   }
 
@@ -408,34 +399,22 @@ final class ConfigRegistryImpl implements ConfigRegistry {
 
     // used by subclass
     public final void addCallback(BiConsumer<T, T> callback) {
-      BiConsumer<String, String> callback1 = (oldValue, newValue) -> {
-        // noinspection unchecked
-        T oldValue1 = oldValue != null ? (T) valueParser.apply(oldValue) : null;
-        // noinspection unchecked
-        T newValue1 = newValue != null ? (T) valueParser.apply(newValue) : null;
-        callback.accept(oldValue1, newValue1);
-      };
-      propertyCallbacks.computeIfAbsent(name, name -> new CopyOnWriteArrayList<>());
-      propertyCallbacks.get(name).add(callback1);
+      propertyCallbacks.computeIfAbsent(name, name -> new PropertyCallback<T>(valueParser));
+      // noinspection unchecked
+      propertyCallbacks.get(name).addCallback(callback);
     }
 
     // used by subclass
     public final void addCallback(Executor executor, BiConsumer<T, T> callback) {
-      BiConsumer<String, String> callback1 = (oldValue, newValue) -> {
-        // noinspection unchecked
-        T oldValue1 = oldValue != null ? (T) valueParser.apply(oldValue) : null;
-        // noinspection unchecked
-        T newValue1 = newValue != null ? (T) valueParser.apply(newValue) : null;
-        executor.execute(() -> callback.accept(oldValue1, newValue1));
-      };
-      propertyCallbacks.computeIfAbsent(name, name -> new CopyOnWriteArrayList<>());
-      propertyCallbacks.get(name).add(callback1);
+      propertyCallbacks.computeIfAbsent(name, name -> new PropertyCallback<T>(valueParser));
+      // noinspection unchecked
+      propertyCallbacks.get(name).addCallback(executor, callback);
     }
   }
 
   private class DoubleConfigPropertyImpl extends AbstractConfigProperty<Double> implements DoubleConfigProperty {
 
-    public DoubleConfigPropertyImpl(String name) {
+    DoubleConfigPropertyImpl(String name) {
       super(name, Double::parseDouble);
     }
 
@@ -447,7 +426,7 @@ final class ConfigRegistryImpl implements ConfigRegistry {
 
   private class LongConfigPropertyImpl extends AbstractConfigProperty<Long> implements LongConfigProperty {
 
-    public LongConfigPropertyImpl(String name) {
+    LongConfigPropertyImpl(String name) {
       super(name, Long::parseLong);
     }
 
@@ -459,7 +438,7 @@ final class ConfigRegistryImpl implements ConfigRegistry {
 
   private class BooleanConfigPropertyImpl extends AbstractConfigProperty<Boolean> implements BooleanConfigProperty {
 
-    public BooleanConfigPropertyImpl(String name) {
+    BooleanConfigPropertyImpl(String name) {
       super(name, Boolean::new);
     }
 
@@ -471,7 +450,7 @@ final class ConfigRegistryImpl implements ConfigRegistry {
 
   private class IntConfigPropertyImpl extends AbstractConfigProperty<Integer> implements IntConfigProperty {
 
-    public IntConfigPropertyImpl(String name) {
+    IntConfigPropertyImpl(String name) {
       super(name, Integer::parseInt);
     }
 
@@ -483,7 +462,7 @@ final class ConfigRegistryImpl implements ConfigRegistry {
 
   private class DurationConfigPropertyImpl extends AbstractConfigProperty<Duration> implements DurationConfigProperty {
 
-    public DurationConfigPropertyImpl(String name) {
+    DurationConfigPropertyImpl(String name) {
       super(name, Duration::parse);
     }
 
@@ -495,7 +474,7 @@ final class ConfigRegistryImpl implements ConfigRegistry {
 
   private class ListConfigPropertyImpl<T> extends AbstractConfigProperty<List<T>> implements ListConfigProperty<T> {
 
-    public ListConfigPropertyImpl(String name, Function<String, Object> valueParser) {
+    ListConfigPropertyImpl(String name, Function<String, Object> valueParser) {
       super(name, str -> Arrays.stream(str.split(",")).map(valueParser).collect(Collectors.toList()));
     }
 
@@ -507,7 +486,7 @@ final class ConfigRegistryImpl implements ConfigRegistry {
 
   private class StringConfigPropertyImpl extends AbstractConfigProperty<String> implements StringConfigProperty {
 
-    public StringConfigPropertyImpl(String name) {
+    StringConfigPropertyImpl(String name) {
       super(name, str -> str);
     }
 

--- a/config/src/main/java/io/scalecube/config/ConfigRegistryImpl.java
+++ b/config/src/main/java/io/scalecube/config/ConfigRegistryImpl.java
@@ -393,8 +393,15 @@ final class ConfigRegistryImpl implements ConfigRegistry {
     }
 
     public final Optional<T> value() {
-      // noinspection unchecked
-      return valueAsString().map(str -> (T) valueParser.apply(str));
+      return valueAsString().flatMap(str -> {
+        try {
+          // noinspection unchecked
+          return Optional.of((T) valueParser.apply(str));
+        } catch (Exception e) {
+          LOGGER.error("Exception at valueParser on property: '{}', string value: '{}', cause: {}", name, str, e);
+          return Optional.empty();
+        }
+      });
     }
 
     // used by subclass

--- a/config/src/main/java/io/scalecube/config/PropertyCallback.java
+++ b/config/src/main/java/io/scalecube/config/PropertyCallback.java
@@ -20,7 +20,7 @@ class PropertyCallback<T> implements BiConsumer<String, String> {
   }
 
   void addCallback(BiConsumer<T, T> callback) {
-    callbacks.add((t1, t2) -> invokeCallback(callback, t1, t2));
+    callbacks.add(callback);
   }
 
   void addCallback(Executor executor, BiConsumer<T, T> callback) {
@@ -47,7 +47,7 @@ class PropertyCallback<T> implements BiConsumer<String, String> {
     }
 
     for (BiConsumer<T, T> callback : callbacks) {
-      callback.accept(t1, t2);
+      invokeCallback(callback, t1, t2);
     }
   }
 

--- a/config/src/main/java/io/scalecube/config/PropertyCallback.java
+++ b/config/src/main/java/io/scalecube/config/PropertyCallback.java
@@ -30,27 +30,20 @@ class PropertyCallback<T> implements BiConsumer<String, String> {
   @Override
   public void accept(String s1, String s2) {
     T t1 = null;
-    Exception e1 = null;
     try {
       // noinspection unchecked
       t1 = s1 != null ? (T) valueParser.apply(s1) : null;
     } catch (Exception e) {
-      LOGGER.error("Exception occured on valueParser: '{}', cause: {}", s1, e);
-      e1 = e; // old value parsing error
+      LOGGER.error("Exception occured at valueParser on oldValue: '{}', cause: {}", s1, e);
     }
 
-    T t2 = null;
-    Exception e2 = null;
+    T t2;
     try {
       // noinspection unchecked
       t2 = s2 != null ? (T) valueParser.apply(s2) : null;
     } catch (Exception e) {
-      LOGGER.error("Exception occured at valueParser: '{}', cause: {}", s2, e);
-      e2 = e;
-    }
-
-    if (e1 != null || e2 != null) {
-      return; // parsing failed either on old value or on new value
+      LOGGER.error("Exception occured at valueParser on newValue: '{}', cause: {}", s2, e);
+      return; // parsing failed on new value
     }
 
     for (BiConsumer<T, T> callback : callbacks) {

--- a/config/src/main/java/io/scalecube/config/PropertyCallback.java
+++ b/config/src/main/java/io/scalecube/config/PropertyCallback.java
@@ -1,0 +1,74 @@
+package io.scalecube.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collection;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Executor;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+
+class PropertyCallback<T> implements BiConsumer<String, String> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PropertyCallback.class);
+
+  private final Function<String, Object> valueParser;
+  private final Collection<BiConsumer<T, T>> callbacks = new CopyOnWriteArrayList<>();
+
+  PropertyCallback(Function<String, Object> valueParser) {
+    this.valueParser = valueParser;
+  }
+
+  void addCallback(BiConsumer<T, T> callback) {
+    callbacks.add((t1, t2) -> {
+      try {
+        callback.accept(t1, t2);
+      } catch (Exception e) {
+        LOGGER.error("Exception occurred on property-change callback: {}, oldValue={}, newValue={}, cause: {}",
+            callback, t1, t2, e, e);
+      }
+    });
+  }
+
+  void addCallback(Executor executor, BiConsumer<T, T> callback) {
+    callbacks.add((t1, t2) -> executor.execute(() -> {
+      try {
+        callback.accept(t1, t2);
+      } catch (Exception e) {
+        LOGGER.error("Exception occurred on property-change callback: {}, oldValue={}, newValue={}, cause: {}",
+            callback, t1, t2, e, e);
+      }
+    }));
+  }
+
+  @Override
+  public void accept(String s1, String s2) {
+    T t1 = null;
+    Exception e1 = null;
+    try {
+      // noinspection unchecked
+      t1 = s1 != null ? (T) valueParser.apply(s1) : null;
+    } catch (Exception e) {
+      LOGGER.error("Exception occured on valueParser: '{}', cause: {}", s1, e);
+      e1 = e; // old value parsing error
+    }
+
+    T t2 = null;
+    Exception e2 = null;
+    try {
+      // noinspection unchecked
+      t2 = s2 != null ? (T) valueParser.apply(s2) : null;
+    } catch (Exception e) {
+      LOGGER.error("Exception occured at valueParser: '{}', cause: {}", s2, e);
+      e2 = e;
+    }
+
+    if (e1 != null || e2 != null) {
+      return; // parsing failed either on old value or on new value
+    }
+
+    for (BiConsumer<T, T> callback : callbacks) {
+      callback.accept(t1, t2);
+    }
+  }
+}

--- a/config/src/main/java/io/scalecube/config/PropertyCallback.java
+++ b/config/src/main/java/io/scalecube/config/PropertyCallback.java
@@ -20,25 +20,11 @@ class PropertyCallback<T> implements BiConsumer<String, String> {
   }
 
   void addCallback(BiConsumer<T, T> callback) {
-    callbacks.add((t1, t2) -> {
-      try {
-        callback.accept(t1, t2);
-      } catch (Exception e) {
-        LOGGER.error("Exception occurred on property-change callback: {}, oldValue={}, newValue={}, cause: {}",
-            callback, t1, t2, e, e);
-      }
-    });
+    callbacks.add((t1, t2) -> invokeCallback(callback, t1, t2));
   }
 
   void addCallback(Executor executor, BiConsumer<T, T> callback) {
-    callbacks.add((t1, t2) -> executor.execute(() -> {
-      try {
-        callback.accept(t1, t2);
-      } catch (Exception e) {
-        LOGGER.error("Exception occurred on property-change callback: {}, oldValue={}, newValue={}, cause: {}",
-            callback, t1, t2, e, e);
-      }
-    }));
+    callbacks.add((t1, t2) -> executor.execute(() -> invokeCallback(callback, t1, t2)));
   }
 
   @Override
@@ -69,6 +55,15 @@ class PropertyCallback<T> implements BiConsumer<String, String> {
 
     for (BiConsumer<T, T> callback : callbacks) {
       callback.accept(t1, t2);
+    }
+  }
+
+  private void invokeCallback(BiConsumer<T, T> callback, T t1, T t2) {
+    try {
+      callback.accept(t1, t2);
+    } catch (Exception e) {
+      LOGGER.error("Exception occurred on property-change callback: {}, oldValue={}, newValue={}, cause: {}",
+          callback, t1, t2, e, e);
     }
   }
 }

--- a/config/src/main/java/io/scalecube/config/PropertyCallback.java
+++ b/config/src/main/java/io/scalecube/config/PropertyCallback.java
@@ -37,13 +37,12 @@ class PropertyCallback<T> implements BiConsumer<String, String> {
       LOGGER.error("Exception occured at valueParser on oldValue: '{}', cause: {}", s1, e);
     }
 
-    T t2;
+    T t2 = null;
     try {
       // noinspection unchecked
       t2 = s2 != null ? (T) valueParser.apply(s2) : null;
     } catch (Exception e) {
       LOGGER.error("Exception occured at valueParser on newValue: '{}', cause: {}", s2, e);
-      return; // parsing failed on new value
     }
 
     for (BiConsumer<T, T> callback : callbacks) {


### PR DESCRIPTION
**Motivation:** don't invoke `valueParser` on every registered callback, this may lead to several parsing exceptions, (if string value can't be parsed of course) . Instead make invocation of `valueParser` to happen only one time.
