### PR TITLE
Changed getting address for localhost

### DIFF
--- a/config/src/main/java/io/scalecube/config/ConfigRegistrySettings.java
+++ b/config/src/main/java/io/scalecube/config/ConfigRegistrySettings.java
@@ -37,14 +37,14 @@ public final class ConfigRegistrySettings {
       sourcesTmp.put(name, builder.sources.get(name));
     }
     this.sources = Collections.unmodifiableMap(sourcesTmp);
-    this.host = builder.host != null ? builder.host : resolveHost();
+    this.host = builder.host != null ? builder.host : resolveLocalHost();
     this.jmxEnabled = builder.jmxEnabled;
     this.jmxMBeanName = builder.jmxMBeanName;
   }
 
-  private static String resolveHost() {
+  private static String resolveLocalHost() {
     try {
-      return InetAddress.getLocalHost().getCanonicalHostName();
+      return InetAddress.getLocalHost().getHostAddress();
     } catch (Exception e) {
       return "unresolved";
     }


### PR DESCRIPTION
The call `InetAddress.getLocalHost().getCanonicalHostName()` on containerized environment, like docker, returns a string like `cb48b181d099`. This string is no-sense for debug and audit purpose., hense it's better to use `getHostAddress()` which returns ip address.