### PR TITLE
Added zookeeper support

### DIFF
--- a/config-examples/pom.xml
+++ b/config-examples/pom.xml
@@ -26,6 +26,11 @@
         </dependency>
         <dependency>
             <groupId>io.scalecube</groupId>
+            <artifactId>config-zookeeper</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.scalecube</groupId>
             <artifactId>config-http-server</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/config-examples/src/main/java/io/scalecube/config/examples/ZookeeperConfigExample.java
+++ b/config-examples/src/main/java/io/scalecube/config/examples/ZookeeperConfigExample.java
@@ -1,0 +1,76 @@
+package io.scalecube.config.examples;
+
+import io.scalecube.config.ConfigRegistry;
+import io.scalecube.config.ConfigRegistrySettings;
+import io.scalecube.config.StringConfigProperty;
+import io.scalecube.config.audit.Slf4JConfigEventListener;
+import io.scalecube.config.keyvalue.KeyValueConfigSource;
+import io.scalecube.config.zookeeper.ZookeeperConfigConnector;
+import io.scalecube.config.zookeeper.ZookeeperConfigEventListener;
+import io.scalecube.config.zookeeper.ZookeeperConfigRepository;
+
+/**
+ * For program properly functioning add some data to zookeeper.
+ * <ul>
+ * <li>Collection {@code group1.config_source} must have: {@code prop1->value-from-group1}</li>
+ * <li>Collection {@code group2.config_source} must have: {@code prop1->value-from-group2}</li>
+ * <li>Collection {@code group3.config_source} must have: {@code prop2->value-from-group3}</li>
+ * <li>Collection {@code config_source} must have: {@code propRoot->value-from-root}</li>
+ * </ul>
+ * <p/>
+ * <b>NOTE:</b> A document in certain collection comes in format:
+ * <p>
+ * <pre>
+ *   {
+ *     "config" :
+ *     [ {
+ *         "propName" : "prop1",
+ *         "propValue" : "prop_value_1"
+ *       },
+ *       {
+ *         "propName" : "prop2",
+ *         "propValue" : "prop_value_2"
+ *       },
+ *       ...
+ *       {
+ *         "propName" : "propRoot",
+ *         "propValue" : "prop_value_N"
+ *       }
+ *     ]
+ *   }
+ * </pre>
+ */
+public class ZookeeperConfigExample {
+
+  public static void main(String[] args) throws Exception {
+    ZookeeperConfigConnector connector = ZookeeperConfigConnector.Builder.forUri("192.168.99.100:2181").build();
+    String configSourceCollectionName = "ZookeeperConfigRepository";
+    String auditLogCollectionName = "TestConfigurationAuditLog";
+
+    KeyValueConfigSource zookeeperConfigSource = KeyValueConfigSource
+        .withRepository(new ZookeeperConfigRepository(connector), configSourceCollectionName)
+        .groups("group1", "group2", "group3")
+        .build();
+
+    ConfigRegistry configRegistry = ConfigRegistry.create(
+        ConfigRegistrySettings.builder()
+            .addLastSource("ZookeeperConfig", zookeeperConfigSource)
+            .addListener(new Slf4JConfigEventListener())
+            .addListener(new ZookeeperConfigEventListener(connector, auditLogCollectionName))
+            .keepRecentConfigEvents(3)
+            .reloadIntervalSec(1)
+            .build());
+
+    StringConfigProperty prop1 = configRegistry.stringProperty("prop1");
+    System.out.println("### Initial zookeeper config property: prop1=" + prop1.value().get() +
+        ", group=" + prop1.origin().get());
+
+    StringConfigProperty prop2 = configRegistry.stringProperty("prop2");
+    System.out.println("### Initial zookeeper config property: prop2=" + prop2.value().get() +
+        ", group=" + prop2.origin().get());
+
+    StringConfigProperty propRoot = configRegistry.stringProperty("propRoot");
+    System.out.println("### Initial zookeeper config **root** property: propRoot=" + propRoot.value().get() +
+        ", group=" + propRoot.origin().get());
+  }
+}

--- a/config-zookeeper/pom.xml
+++ b/config-zookeeper/pom.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>config-parent</artifactId>
+        <groupId>io.scalecube</groupId>
+        <version>0.3.2-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>config-zookeeper</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.scalecube</groupId>
+            <artifactId>config</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/config-zookeeper/src/main/java/io/scalecube/config/zookeeper/ZookeeperConfigConnector.java
+++ b/config-zookeeper/src/main/java/io/scalecube/config/zookeeper/ZookeeperConfigConnector.java
@@ -1,0 +1,47 @@
+package io.scalecube.config.zookeeper;
+
+import io.scalecube.config.utils.ThrowableUtil;
+import org.apache.zookeeper.ZooKeeper;
+
+public class ZookeeperConfigConnector {
+
+  public static final int DEFAULT_SESSION_TIMEOUT = 5000;
+
+  private final ZooKeeper zooKeeper;
+
+  private ZookeeperConfigConnector(Builder builder) {
+    try {
+      this.zooKeeper = new ZooKeeper(builder.connectionString, builder.sessionTimeout, null, true);
+    } catch (Exception e) {
+      throw ThrowableUtil.propagate(e);
+    }
+  }
+
+  public ZooKeeper getClient() {
+    return zooKeeper;
+  }
+
+  public static class Builder {
+
+    private String connectionString;
+    private int sessionTimeout = DEFAULT_SESSION_TIMEOUT;
+
+    public static Builder forUri(String uri) {
+      return new Builder().connectionString(uri);
+    }
+
+    public Builder connectionString(String connectionString) {
+      this.connectionString = connectionString;
+      return this;
+    }
+
+    public Builder sessionTimeout(int sessionTimeout) {
+      this.sessionTimeout = sessionTimeout;
+      return this;
+    }
+
+    public ZookeeperConfigConnector build() {
+      return new ZookeeperConfigConnector(this);
+    }
+  }
+}

--- a/config-zookeeper/src/main/java/io/scalecube/config/zookeeper/ZookeeperConfigEventListener.java
+++ b/config-zookeeper/src/main/java/io/scalecube/config/zookeeper/ZookeeperConfigEventListener.java
@@ -1,0 +1,212 @@
+package io.scalecube.config.zookeeper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.scalecube.config.audit.ConfigEvent;
+import io.scalecube.config.audit.ConfigEventListener;
+import io.scalecube.config.utils.ThrowableUtil;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.data.ACL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nonnull;
+import java.io.ByteArrayOutputStream;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+
+public class ZookeeperConfigEventListener implements ConfigEventListener {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperConfigEventListener.class);
+
+  private static final DateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
+
+  private static final ThreadFactory threadFactory;
+
+  static {
+    threadFactory = r -> {
+      Thread thread = new Thread(r);
+      thread.setDaemon(true);
+      thread.setName("zookeeper-config-auditor");
+      thread.setUncaughtExceptionHandler((t, e) -> LOGGER.error("Exception occurred: " + e, e));
+      return thread;
+    };
+  }
+
+  private static final Executor executor = Executors.newSingleThreadExecutor(threadFactory);
+
+  private final ZookeeperConfigConnector connector;
+  private final String collectionPath;
+
+  public ZookeeperConfigEventListener(@Nonnull ZookeeperConfigConnector connector, @Nonnull String collectionPath) {
+    this.connector = connector;
+    this.collectionPath = "/" + collectionPath;
+    create(this.collectionPath, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+  }
+
+  @Override
+  public void onEvent(ConfigEvent event) {
+    CompletableFuture.runAsync(() -> {
+      AuditLogEvent entity = new AuditLogEvent();
+      entity.setName(event.getName());
+      entity.setTimestamp(event.getTimestamp());
+      entity.setHost(event.getHost());
+      entity.setType(event.getType().toString());
+      entity.setNewSource(event.getNewSource());
+      entity.setNewOrigin(event.getNewOrigin());
+      entity.setNewValue(event.getNewValue());
+      entity.setOldSource(event.getOldSource());
+      entity.setOldOrigin(event.getOldOrigin());
+      entity.setOldValue(event.getOldValue());
+      insertOne(entity);
+    }, executor);
+  }
+
+  private void insertOne(AuditLogEvent event) {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try {
+      ObjectMapper objectMapper = ZookeeperConfigObjectMapper.getInstance();
+      objectMapper.writer().writeValue(baos, event);
+    } catch (Exception e) {
+      LOGGER.error("Exception at converting obj: {} to json, cause: {}", event, e);
+      throw ThrowableUtil.propagate(e);
+    }
+    create(event, baos.toByteArray());
+  }
+
+  private void create(AuditLogEvent event, byte[] data) {
+    String path = collectionPath + "/" + DATE_FORMAT.format(event.getTimestamp());
+    create(path, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    path += "/" + event.getName();
+    create(path, null, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    path += "/event-";
+    create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT_SEQUENTIAL);
+  }
+
+  private void create(String path, byte[] data, List<ACL> acl, CreateMode mode) {
+    try {
+      connector.getClient().create(path, data, acl, mode);
+    } catch (KeeperException.NodeExistsException e) {
+      if (data != null) { // is it end point?
+        throw ThrowableUtil.propagate(e);
+      }
+    } catch (Exception e) {
+      throw ThrowableUtil.propagate(e);
+    }
+  }
+
+  private static class AuditLogEvent {
+    private String name;
+    private Date timestamp;
+    private String type;
+    private String host;
+    private String oldSource;
+    private String oldOrigin;
+    private String oldValue;
+    private String newSource;
+    private String newOrigin;
+    private String newValue;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+
+    public Date getTimestamp() {
+      return timestamp;
+    }
+
+    public void setTimestamp(Date timestamp) {
+      this.timestamp = timestamp;
+    }
+
+    public String getHost() {
+      return host;
+    }
+
+    public void setHost(String host) {
+      this.host = host;
+    }
+
+    public String getOldSource() {
+      return oldSource;
+    }
+
+    public void setOldSource(String oldSource) {
+      this.oldSource = oldSource;
+    }
+
+    public String getOldOrigin() {
+      return oldOrigin;
+    }
+
+    public void setOldOrigin(String oldOrigin) {
+      this.oldOrigin = oldOrigin;
+    }
+
+    public String getOldValue() {
+      return oldValue;
+    }
+
+    public void setOldValue(String oldValue) {
+      this.oldValue = oldValue;
+    }
+
+    public String getNewSource() {
+      return newSource;
+    }
+
+    public void setNewSource(String newSource) {
+      this.newSource = newSource;
+    }
+
+    public String getNewOrigin() {
+      return newOrigin;
+    }
+
+    public void setNewOrigin(String newOrigin) {
+      this.newOrigin = newOrigin;
+    }
+
+    public String getNewValue() {
+      return newValue;
+    }
+
+    public void setNewValue(String newValue) {
+      this.newValue = newValue;
+    }
+
+    @Override
+    public String toString() {
+      return "AuditLogEvent{" +
+          "name='" + name + '\'' +
+          ", timestamp=" + timestamp +
+          ", type='" + type + '\'' +
+          ", host='" + host + '\'' +
+          ", oldSource='" + oldSource + '\'' +
+          ", oldOrigin='" + oldOrigin + '\'' +
+          ", oldValue='" + oldValue + '\'' +
+          ", newSource='" + newSource + '\'' +
+          ", newOrigin='" + newOrigin + '\'' +
+          ", newValue='" + newValue + '\'' +
+          '}';
+    }
+  }
+}

--- a/config-zookeeper/src/main/java/io/scalecube/config/zookeeper/ZookeeperConfigObjectMapper.java
+++ b/config-zookeeper/src/main/java/io/scalecube/config/zookeeper/ZookeeperConfigObjectMapper.java
@@ -1,0 +1,23 @@
+package io.scalecube.config.zookeeper;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+public class ZookeeperConfigObjectMapper {
+
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
+  static {
+    objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+  }
+
+  private ZookeeperConfigObjectMapper() {
+    // Do not instantiate
+  }
+
+  public static ObjectMapper getInstance() {
+    return objectMapper;
+  }
+}

--- a/config-zookeeper/src/main/java/io/scalecube/config/zookeeper/ZookeeperConfigRepository.java
+++ b/config-zookeeper/src/main/java/io/scalecube/config/zookeeper/ZookeeperConfigRepository.java
@@ -1,0 +1,48 @@
+package io.scalecube.config.zookeeper;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectReader;
+import io.scalecube.config.keyvalue.KeyValueConfigEntity;
+import io.scalecube.config.keyvalue.KeyValueConfigName;
+import io.scalecube.config.keyvalue.KeyValueConfigRepository;
+
+import javax.annotation.Nonnull;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class ZookeeperConfigRepository implements KeyValueConfigRepository {
+  private final ZookeeperConfigConnector connector;
+
+  public ZookeeperConfigRepository(@Nonnull ZookeeperConfigConnector connector) {
+    this.connector = Objects.requireNonNull(connector);
+  }
+
+  @Override
+  public List<KeyValueConfigEntity> findAll(@Nonnull KeyValueConfigName configName) throws Exception {
+    String collectionPath = "/" + configName.getQualifiedName();
+    byte[] data = connector.getClient().getData(collectionPath, false, null);
+    ByteArrayInputStream bin = new ByteArrayInputStream(data);
+    ObjectMapper objectMapper = ZookeeperConfigObjectMapper.getInstance();
+    ObjectReader objectReader = objectMapper.readerFor(ZookeeperConfigEntity.class);
+    return ((ZookeeperConfigEntity) objectReader.readValue(bin)).getConfig().stream()
+        .map(input -> input.setConfigName(configName))
+        .collect(Collectors.toList());
+  }
+
+  private static class ZookeeperConfigEntity {
+    private List<KeyValueConfigEntity> config;
+
+    public ZookeeperConfigEntity() {
+    }
+
+    public List<KeyValueConfigEntity> getConfig() {
+      return config;
+    }
+
+    public void setConfig(List<KeyValueConfigEntity> config) {
+      this.config = config;
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <jackson.version>2.8.8</jackson.version>
         <bson4jackson.version>2.7.0</bson4jackson.version>
         <mongo-java-driver.version>3.4.2</mongo-java-driver.version>
+        <zookeeper.version>3.4.11</zookeeper.version>
         <findbugs.version>2.0.3</findbugs.version>
         <slf4j.version>1.7.7</slf4j.version>
         <jersey.version>2.26-b09</jersey.version>
@@ -80,6 +81,7 @@
         <module>config-mongo</module>
         <module>config-http-server</module>
         <module>config-examples</module>
+        <module>config-zookeeper</module>
     </modules>
 
     <dependencyManagement>
@@ -118,6 +120,11 @@
                 <groupId>org.mongodb</groupId>
                 <artifactId>mongo-java-driver</artifactId>
                 <version>${mongo-java-driver.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.zookeeper</groupId>
+                <artifactId>zookeeper</artifactId>
+                <version>${zookeeper.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
[issues#5](https://github.com/scalecube/config/issues/5)

TIPS

- Zookeeper UI, use docker-compose file from https://hub.docker.com/r/elkozmon/zoonavigator-api/
- before start needs to create config path in Zookeeper, for example, ZookeeperConfigExample needs  ZookeeperConfigRepository path in Zookeeper. And also fill this key with JSON data, for example, ZookeeperConfigExample will be searching for 'prop1' ,'prop2', 'propRoot' properties:
```json
{
  "config" :
  [ {
      "propName" : "prop1",
      "propValue" : "prop_value_1"
    },
    {
      "propName" : "prop2",
      "propValue" : "prop_value_2"
    },
    {
      "propName" : "propRoot",
      "propValue" : "prop_value_N"
    }
  ]
}
```
- to start Zookeeper use following command:
`docker run -d -p 2181:2181 --name config_zookeeper zookeeper`
